### PR TITLE
request for improvements: fix empty autolink import with new reference

### DIFF
--- a/github/resource_github_repository_autolink_reference.go
+++ b/github/resource_github_repository_autolink_reference.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -44,6 +45,9 @@ func resourceGithubRepositoryAutolinkReference() *schema.Resource {
 						return nil, err
 					}
 
+					if autolink.ID == nil {
+						return nil, errors.New("Autolink doesn't exist")
+					}
 					id = strconv.FormatInt(*autolink.ID, 10)
 				}
 


### PR DESCRIPTION
This is a demonstration fix of the crash when running an import of an empty name autolink in a non-empty plan adding an autolink reference.

The fix is rudimentary and must be improved. For instance, maybe we could directly handle the case inside `getAutolinkByKeyPrefix`. 

# How to test the fix

1. Clone the repository https://github.com/pix4d/terraform-provider-github, checkout this branch
2. In your local terraform configuration file (`~/.terraformrc`), add a development override of the github provider pointing to the cloned repository:

```terraform
provider_installation {
  dev_overrides {
    "integrations/github" = <path-to-github-provider>
  }

  direct {}
}
```

3. Make the plan non-empty by adding a bogus autolink reference to a chosen team. Here we are using `locks`:

```terraform
diff --git a/prod/locks/repos.tf b/prod/locks/repos.tf
index e467d08..4e74e8a 100644
--- a/prod/locks/repos.tf
+++ b/prod/locks/repos.tf
@@ -20,7 +20,7 @@ locals {
     visibility             = "private"
     vulnerability_alerts   = true
 
-    autolinks = ["PCI"]
+    autolinks = ["PCI", "FOO"]
 
     bp_default_rule_config = {
       enforce_admins                  = false
```

4. Try to import an empty autolink using the new reference: `aws-vault exec pix4d-users -- erraform import 'module.github.github_repository_autolink_reference.repo_autolinks["concourse-locks-engine.FOO-"]' 'concourse-locks-engine/FOO-'`

# Comparison

## Without the fix (without the dev override)

```
 (master)> av -- terraform import 'module.github.github_repository_autolink_reference.repo_autolinks["concourse-locks-engine.FOO-"]' 'concourse-locks-engine/FOO-'
module.github.data.github_organization_teams.all: Reading...
module.github.data.github_user.users["Pix4D-Janus"]: Reading...
module.github.github_repository_autolink_reference.repo_autolinks["concourse-locks-engine.FOO-"]: Importing from ID "concourse-locks-engine/FOO-"...
module.github.data.github_organization_teams.all: Read complete after 5s [id=MDEyOk9yZ2FuaXphdGlvbjc2NTU3NDg=]
╷
│ Error: Request cancelled
│ 
│ The plugin.(*GRPCProvider).ImportResourceState request was cancelled.
╵

╷
│ Error: Request cancelled
│ 
│   with module.github.data.github_user.users["Pix4D-Janus"],
│   on ../../tf-modules/github/main.tf line 113, in data "github_user" "users":
│  113: data "github_user" "users" {
│ 
│ The plugin.(*GRPCProvider).ReadDataSource request was cancelled.
╵


Stack trace from the terraform-provider-github_v6.0.1 plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xcb5b3d]

goroutine 114 [running]:
github.com/integrations/terraform-provider-github/v6/github.resourceGithubRepositoryAutolinkReference.func1(0xc0005aa400, {0xd169e0, 0xc00062af40})
	github.com/integrations/terraform-provider-github/v6/github/resource_github_repository_autolink_reference.go:47 +0x15d
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Provider).ImportState(0xc0002ec600, {0x104d380, 0xc00049f560}, 0xc000187698, {0xc00051c020, 0x1b})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.33.0/helper/schema/provider.go:396 +0x1b9
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ImportResourceState(0xc000386540, {0x104d380?, 0xc00049f4a0?}, 0xc0006e80a0)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.33.0/helper/schema/grpc_provider.go:1148 +0xe9
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ImportResourceState(0xc00024f7c0, {0x104d380?, 0xc00049e9f0?}, 0xc000566140)
	github.com/hashicorp/terraform-plugin-go@v0.22.0/tfprotov5/tf5server/server.go:875 +0x1f0
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ImportResourceState_Handler({0xeb58e0, 0xc00024f7c0}, {0x104d380, 0xc00049e9f0}, 0xc0005aa000, 0x0)
	github.com/hashicorp/terraform-plugin-go@v0.22.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:536 +0x1a6
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0001b7000, {0x104d380, 0xc00049e960}, {0x1051c18, 0xc0003a56c0}, 0xc000634240, 0xc0003fbe90, 0x16cc6b0, 0x0)
	google.golang.org/grpc@v1.61.1/server.go:1385 +0xdd1
google.golang.org/grpc.(*Server).handleStream(0xc0001b7000, {0x1051c18, 0xc0003a56c0}, 0xc000634240)
	google.golang.org/grpc@v1.61.1/server.go:1796 +0xfb8
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	google.golang.org/grpc@v1.61.1/server.go:1029 +0x8b
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 12
	google.golang.org/grpc@v1.61.1/server.go:1040 +0x125

Error: The terraform-provider-github_v6.0.1 plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```

## With the fix (with the development override)

```
 (master)> av -- terraform import 'module.github.github_repository_autolink_reference.repo_autolinks["concourse-locks-engine.FOO-"]' 'concourse-locks-engine/FOO-'
module.github.data.github_organization_teams.all: Reading...
module.github.data.github_user.users["Pix4D-Janus"]: Reading...
module.github.github_repository_autolink_reference.repo_autolinks["concourse-locks-engine.FOO-"]: Importing from ID "concourse-locks-engine/FOO-"...
module.github.data.github_organization_teams.all: Read complete after 3s [id=MDEyOk9yZ2FuaXphdGlvbjc2NTU3NDg=]
module.github.data.github_user.users["Pix4D-Janus"]: Read complete after 5s [id=46958598]
╷
│ Error: cannot find autolink reference FOO- in repo Pix4D/concourse-locks-engine
│ 
│ 
╵
```

